### PR TITLE
Code review request for EUCA-11809 and EUCA-11823

### DIFF
--- a/clc/modules/object-storage-common/src/main/java/com/eucalyptus/objectstorage/msgs/ObjectStorage.groovy
+++ b/clc/modules/object-storage-common/src/main/java/com/eucalyptus/objectstorage/msgs/ObjectStorage.groovy
@@ -83,6 +83,7 @@ public class ObjectStorageRequestType extends BaseMessage {
   BucketLogData logData;
   protected String bucket;
   protected String key;
+  protected String versionId;
 
   public ObjectStorageRequestType() {}
 
@@ -117,6 +118,14 @@ public class ObjectStorageRequestType extends BaseMessage {
 
   public Date getTimestamp() {
     return this.timeStamp;
+  }
+
+  public String getVersionId() {
+    return this.versionId;
+  }
+
+  public void setVersionId(String versionId) {
+    this.versionId = versionId;
   }
 
   public UserPrincipal getUser() {
@@ -266,7 +275,7 @@ public class ObjectStorageRedirectMessageType extends ObjectStorageErrorMessageT
 /* GET /bucket?acl */
 
 @AdminOverrideAllowed
-@RequiresPermission([PolicySpec.S3_GETBUCKETACL])
+@RequiresPermission(standard = [PolicySpec.S3_GETBUCKETACL], version = [])
 @ResourceType(PolicySpec.S3_RESOURCE_BUCKET)
 @RequiresACLPermission(object = [], bucket = [ObjectStorageProperties.Permission.READ_ACP])
 public class GetBucketAccessControlPolicyType extends ObjectStorageRequestType {}
@@ -278,11 +287,10 @@ public class GetBucketAccessControlPolicyResponseType extends ObjectStorageRespo
 /* GET /bucket/object?acl */
 
 @AdminOverrideAllowed
-@RequiresPermission([PolicySpec.S3_GETOBJECTACL])
+@RequiresPermission(standard = [PolicySpec.S3_GETOBJECTACL], version = [PolicySpec.S3_GETOBJECTVERSIONACL])
 @ResourceType(PolicySpec.S3_RESOURCE_OBJECT)
 @RequiresACLPermission(object = [ObjectStorageProperties.Permission.READ_ACP], bucket = [])
 public class GetObjectAccessControlPolicyType extends ObjectStorageRequestType {
-  String versionId;
 }
 
 public class GetObjectAccessControlPolicyResponseType extends ObjectStorageResponseType {
@@ -299,7 +307,7 @@ public class GetObjectAccessControlPolicyResponseType extends ObjectStorageRespo
  */
 
 @AdminOverrideAllowed
-@RequiresPermission([PolicySpec.S3_LISTALLMYBUCKETS])
+@RequiresPermission(standard = [PolicySpec.S3_LISTALLMYBUCKETS], version = [])
 @ResourceType(PolicySpec.S3_RESOURCE_BUCKET)
 @RequiresACLPermission(object = [], bucket = [], ownerOnly = true, ownerOf = [ObjectStorageProperties.Resource.bucket])
 public class ListAllMyBucketsType extends ObjectStorageRequestType {}
@@ -312,7 +320,7 @@ public class ListAllMyBucketsResponseType extends ObjectStorageResponseType {
 /* HEAD /bucket */
 
 @AdminOverrideAllowed
-@RequiresPermission([PolicySpec.S3_LISTBUCKET])
+@RequiresPermission(standard = [PolicySpec.S3_LISTBUCKET], version = [])
 @ResourceType(PolicySpec.S3_RESOURCE_BUCKET)
 @RequiresACLPermission(object = [], bucket = [ObjectStorageProperties.Permission.READ])
 public class HeadBucketType extends ObjectStorageRequestType {}
@@ -322,7 +330,7 @@ public class HeadBucketResponseType extends ObjectStorageResponseType {}
 /* PUT /bucket */
 
 @AdminOverrideAllowed
-@RequiresPermission([PolicySpec.S3_CREATEBUCKET])
+@RequiresPermission(standard = [PolicySpec.S3_CREATEBUCKET], version = [])
 @ResourceType(PolicySpec.S3_RESOURCE_BUCKET)
 @RequiresACLPermission(object = [], bucket = [], ownerOnly = true, ownerOf = [ObjectStorageProperties.Resource.bucket])
 //No ACLs for creating a bucket, weird like ListAllMyBuckets.
@@ -361,7 +369,7 @@ public class CreateBucketResponseType extends ObjectStorageResponseType {
 /* DELETE /bucket */
 
 @AdminOverrideAllowed
-@RequiresPermission([PolicySpec.S3_DELETEBUCKET])
+@RequiresPermission(standard = [PolicySpec.S3_DELETEBUCKET], version = [])
 @ResourceType(PolicySpec.S3_RESOURCE_BUCKET)
 @RequiresACLPermission(object = [], bucket = [], ownerOnly = true, ownerOf = [ObjectStorageProperties.Resource.bucket])
 //No ACLs for deleting a bucket, only owner account can delete
@@ -372,7 +380,7 @@ public class DeleteBucketResponseType extends ObjectStorageResponseType {}
 /* PUT /bucket/object */
 
 @AdminOverrideAllowed
-@RequiresPermission([PolicySpec.S3_PUTOBJECT])
+@RequiresPermission(standard = [PolicySpec.S3_PUTOBJECT], version = [])
 @ResourceType(PolicySpec.S3_RESOURCE_OBJECT)
 @RequiresACLPermission(object = [], bucket = [ObjectStorageProperties.Permission.WRITE])
 //Account must have write access to the bucket
@@ -394,7 +402,7 @@ public class PutObjectResponseType extends ObjectStorageDataResponseType {}
 /* POST /bucket/object */
 
 @AdminOverrideAllowed
-@RequiresPermission([PolicySpec.S3_PUTOBJECT])
+@RequiresPermission(standard = [PolicySpec.S3_PUTOBJECT], version = [])
 @ResourceType(PolicySpec.S3_RESOURCE_OBJECT)
 @RequiresACLPermission(object = [], bucket = [ObjectStorageProperties.Permission.WRITE])
 public class PostObjectType extends ObjectStorageDataRequestType {
@@ -418,7 +426,7 @@ public class PostObjectResponseType extends ObjectStorageDataResponseType {
 /* GET /bucket/object */
 
 @AdminOverrideAllowed
-@RequiresPermission([PolicySpec.S3_GETOBJECT])
+@RequiresPermission(standard = [PolicySpec.S3_GETOBJECT], version = [PolicySpec.S3_GETOBJECTVERSION])
 @ResourceType(PolicySpec.S3_RESOURCE_OBJECT)
 @RequiresACLPermission(object = [ObjectStorageProperties.Permission.READ], bucket = [])
 public class GetObjectType extends ObjectStorageDataGetRequestType {
@@ -426,7 +434,6 @@ public class GetObjectType extends ObjectStorageDataGetRequestType {
   Boolean inlineData;
   Boolean deleteAfterGet;
   Boolean getTorrent;
-  String versionId;
 
   def GetObjectType() {
   }
@@ -446,7 +453,7 @@ public class GetObjectResponseType extends ObjectStorageDataGetResponseType {
 
 //TODO: zhill -- remove this request type and fold into regular GetObject
 @AdminOverrideAllowed
-@RequiresPermission([PolicySpec.S3_GETOBJECT])
+@RequiresPermission(standard = [PolicySpec.S3_GETOBJECT], version = [PolicySpec.S3_GETOBJECTVERSION])
 @ResourceType(PolicySpec.S3_RESOURCE_OBJECT)
 @RequiresACLPermission(object = [ObjectStorageProperties.Permission.READ], bucket = [])
 public class GetObjectExtendedType extends ObjectStorageDataGetRequestType {
@@ -459,7 +466,6 @@ public class GetObjectExtendedType extends ObjectStorageDataGetRequestType {
   String ifMatch;
   String ifNoneMatch;
   Boolean returnCompleteObjectOnConditionFailure;
-  String versionId;
 }
 
 public class GetObjectExtendedResponseType extends ObjectStorageDataGetResponseType {
@@ -468,7 +474,7 @@ public class GetObjectExtendedResponseType extends ObjectStorageDataGetResponseT
 /* PUT /bucket/object with x-amz-copy-src header */
 
 @AdminOverrideAllowed
-@RequiresPermission([PolicySpec.S3_GETOBJECT])
+@RequiresPermission(standard = [], version = [])
 @ResourceType(PolicySpec.S3_RESOURCE_OBJECT)
 //TODO: need to add support for both, refactor annotation into a set of k,v pairs
 @RequiresACLPermission(object = [ObjectStorageProperties.Permission.READ], bucket = [ObjectStorageProperties.Permission.WRITE])
@@ -515,25 +521,6 @@ public class CopyObjectType extends ObjectStorageRequestType {
   }
 }
 
-/* HEAD /bucket/object */
-
-@AdminOverrideAllowed
-@RequiresPermission([PolicySpec.S3_GETOBJECT])
-@ResourceType(PolicySpec.S3_RESOURCE_OBJECT)
-@RequiresACLPermission(object = [ObjectStorageProperties.Permission.READ], bucket = [])
-public class HeadObjectType extends ObjectStorageDataGetRequestType {
-  String versionId;
-
-  def HeadObjectType() {
-  }
-
-  def HeadObjectType(final String bucketName, final String key) {
-    super(bucketName, key);
-  }
-}
-
-public class HeadObjectResponseType extends ObjectStorageDataResponseType {}
-
 public class CopyObjectResponseType extends ObjectStorageResponseType {
   String etag;
   String lastModified;
@@ -545,6 +532,23 @@ public class CopyObjectResponseType extends ObjectStorageResponseType {
   String versionId;
   String copySourceVersionId;
 }
+
+/* HEAD /bucket/object */
+
+@AdminOverrideAllowed
+@RequiresPermission(standard = [PolicySpec.S3_GETOBJECT], version = [PolicySpec.S3_GETOBJECTVERSION])
+@ResourceType(PolicySpec.S3_RESOURCE_OBJECT)
+@RequiresACLPermission(object = [ObjectStorageProperties.Permission.READ], bucket = [])
+public class HeadObjectType extends ObjectStorageDataGetRequestType {
+  def HeadObjectType() {
+  }
+
+  def HeadObjectType(final String bucketName, final String key) {
+    super(bucketName, key);
+  }
+}
+
+public class HeadObjectResponseType extends ObjectStorageDataResponseType {}
 
 //TODO: REMOVE THIS
 /* SOAP put object */
@@ -564,7 +568,7 @@ public class PutObjectInlineResponseType extends ObjectStorageDataResponseType {
 /* DELETE /bucket/object */
 
 @AdminOverrideAllowed
-@RequiresPermission([PolicySpec.S3_DELETEOBJECT])
+@RequiresPermission(standard = [PolicySpec.S3_DELETEOBJECT], version = [])
 @ResourceType(PolicySpec.S3_RESOURCE_OBJECT)
 @RequiresACLPermission(object = [], bucket = [ObjectStorageProperties.Permission.WRITE])
 public class DeleteObjectType extends ObjectStorageRequestType {}
@@ -574,11 +578,10 @@ public class DeleteObjectResponseType extends DeleteResponseType {}
 /* DELETE /bucket/object?versionid=x */
 
 @AdminOverrideAllowed
-@RequiresPermission([PolicySpec.S3_DELETEOBJECTVERSION])
+@RequiresPermission(standard = [PolicySpec.S3_DELETEOBJECTVERSION], version = [])
 @ResourceType(PolicySpec.S3_RESOURCE_OBJECT)
 @RequiresACLPermission(object = [], bucket = [], ownerOnly = true, ownerOf = [ObjectStorageProperties.Resource.bucket])
 public class DeleteVersionType extends ObjectStorageRequestType {
-  String versionId;
 }
 
 public class DeleteVersionResponseType extends DeleteResponseType {}
@@ -591,7 +594,7 @@ public class DeleteResponseType extends ObjectStorageResponseType {
 /* GET /bucket */
 
 @AdminOverrideAllowed
-@RequiresPermission([PolicySpec.S3_LISTBUCKET])
+@RequiresPermission(standard = [PolicySpec.S3_LISTBUCKET], version = [])
 @ResourceType(PolicySpec.S3_RESOURCE_BUCKET)
 @RequiresACLPermission(object = [], bucket = [ObjectStorageProperties.Permission.READ])
 public class ListBucketType extends ObjectStorageRequestType {
@@ -622,7 +625,7 @@ public class ListBucketResponseType extends ObjectStorageResponseType {
 /* GET /bucket?versions */
 
 @AdminOverrideAllowed
-@RequiresPermission([PolicySpec.S3_LISTBUCKETVERSIONS])
+@RequiresPermission(standard = [PolicySpec.S3_LISTBUCKETVERSIONS], version = [])
 @ResourceType(PolicySpec.S3_RESOURCE_BUCKET)
 @RequiresACLPermission(object = [], bucket = [ObjectStorageProperties.Permission.READ] /*, bucketOwnerOnly = true*/) // TODO check bucketOwnerOnly flag necessary
 public class ListVersionsType extends ObjectStorageRequestType {
@@ -654,7 +657,7 @@ public class ListVersionsResponseType extends ObjectStorageResponseType {
 /* PUT /bucket?acl */
 
 @AdminOverrideAllowed
-@RequiresPermission([PolicySpec.S3_PUTBUCKETACL])
+@RequiresPermission(standard = [PolicySpec.S3_PUTBUCKETACL], version = [])
 @ResourceType(PolicySpec.S3_RESOURCE_BUCKET)
 @RequiresACLPermission(object = [], bucket = [ObjectStorageProperties.Permission.WRITE_ACP])
 public class SetBucketAccessControlPolicyType extends ObjectStorageRequestType {
@@ -666,12 +669,11 @@ public class SetBucketAccessControlPolicyResponseType extends ObjectStorageRespo
 /* PUT /bucket/object?acl */
 
 @AdminOverrideAllowed
-@RequiresPermission([PolicySpec.S3_PUTOBJECTACL])
+@RequiresPermission(standard = [PolicySpec.S3_PUTOBJECTACL], version = [PolicySpec.S3_PUTOBJECTVERSIONACL])
 @ResourceType(PolicySpec.S3_RESOURCE_OBJECT)
 @RequiresACLPermission(object = [ObjectStorageProperties.Permission.WRITE_ACP], bucket = [])
 public class SetObjectAccessControlPolicyType extends ObjectStorageRequestType {
   AccessControlPolicy accessControlPolicy;
-  String versionId;
 }
 
 public class SetObjectAccessControlPolicyResponseType extends ObjectStorageResponseType {
@@ -681,7 +683,7 @@ public class SetObjectAccessControlPolicyResponseType extends ObjectStorageRespo
 /* GET /bucket?location */
 
 @AdminOverrideAllowed
-@RequiresPermission([PolicySpec.S3_GETBUCKETLOCATION])
+@RequiresPermission(standard = [PolicySpec.S3_GETBUCKETLOCATION], version = [])
 @ResourceType(PolicySpec.S3_RESOURCE_BUCKET)
 @RequiresACLPermission(object = [], bucket = [], ownerOnly = true, ownerOf = [ObjectStorageProperties.Resource.bucket])
 public class GetBucketLocationType extends ObjectStorageRequestType {}
@@ -693,7 +695,7 @@ public class GetBucketLocationResponseType extends ObjectStorageResponseType {
 /* GET /bucket?logging */
 
 @AdminOverrideAllowed
-@RequiresPermission([PolicySpec.S3_GETBUCKETLOGGING])
+@RequiresPermission(standard = [PolicySpec.S3_GETBUCKETLOGGING], version = [])
 @ResourceType(PolicySpec.S3_RESOURCE_BUCKET)
 @RequiresACLPermission(object = [], bucket = [], ownerOnly = true, ownerOf = [ObjectStorageProperties.Resource.bucket])
 public class GetBucketLoggingStatusType extends ObjectStorageRequestType {}
@@ -705,7 +707,7 @@ public class GetBucketLoggingStatusResponseType extends ObjectStorageResponseTyp
 /* PUT /bucket?logging */
 
 @AdminOverrideAllowed
-@RequiresPermission([PolicySpec.S3_PUTBUCKETLOGGING])
+@RequiresPermission(standard = [PolicySpec.S3_PUTBUCKETLOGGING], version = [])
 @ResourceType(PolicySpec.S3_RESOURCE_BUCKET)
 @RequiresACLPermission(object = [], bucket = [], ownerOnly = true, ownerOf = [ObjectStorageProperties.Resource.bucket])
 public class SetBucketLoggingStatusType extends ObjectStorageRequestType {
@@ -717,7 +719,7 @@ public class SetBucketLoggingStatusResponseType extends ObjectStorageResponseTyp
 /* GET /bucket?versioning */
 
 @AdminOverrideAllowed
-@RequiresPermission([PolicySpec.S3_GETBUCKETVERSIONING])
+@RequiresPermission(standard = [PolicySpec.S3_GETBUCKETVERSIONING], version = [])
 @ResourceType(PolicySpec.S3_RESOURCE_BUCKET)
 @RequiresACLPermission(object = [], bucket = [], ownerOnly = true, ownerOf = [ObjectStorageProperties.Resource.bucket])
 public class GetBucketVersioningStatusType extends ObjectStorageRequestType {}
@@ -733,7 +735,7 @@ public class GetBucketVersioningStatusResponseType extends ObjectStorageResponse
 /* PUT /bucket?versioning */
 
 @AdminOverrideAllowed
-@RequiresPermission([PolicySpec.S3_PUTBUCKETVERSIONING])
+@RequiresPermission(standard = [PolicySpec.S3_PUTBUCKETVERSIONING], version = [])
 @ResourceType(PolicySpec.S3_RESOURCE_BUCKET)
 @RequiresACLPermission(object = [], bucket = [], ownerOnly = true, ownerOf = [ObjectStorageProperties.Resource.bucket])
 public class SetBucketVersioningStatusType extends ObjectStorageRequestType {
@@ -745,7 +747,7 @@ public class SetBucketVersioningStatusResponseType extends ObjectStorageResponse
 /* GET /bucket?lifecycle */
 
 @AdminOverrideAllowed
-@RequiresPermission([PolicySpec.S3_GETLIFECYCLECONFIGURATION])
+@RequiresPermission(standard = [PolicySpec.S3_GETLIFECYCLECONFIGURATION], version = [])
 @ResourceType(PolicySpec.S3_RESOURCE_BUCKET)
 @RequiresACLPermission(object = [], bucket = [], ownerOnly = true, ownerOf = [ObjectStorageProperties.Resource.bucket])
 public class GetBucketLifecycleType extends ObjectStorageRequestType {}
@@ -757,7 +759,7 @@ public class GetBucketLifecycleResponseType extends ObjectStorageResponseType {
 /* PUT /bucket?lifecycle */
 
 @AdminOverrideAllowed
-@RequiresPermission([PolicySpec.S3_PUTLIFECYCLECONFIGURATION])
+@RequiresPermission(standard = [PolicySpec.S3_PUTLIFECYCLECONFIGURATION], version = [])
 @ResourceType(PolicySpec.S3_RESOURCE_BUCKET)
 @RequiresACLPermission(object = [], bucket = [], ownerOnly = true, ownerOf = [ObjectStorageProperties.Resource.bucket])
 public class SetBucketLifecycleType extends ObjectStorageRequestType {
@@ -770,7 +772,7 @@ public class SetBucketLifecycleResponseType extends ObjectStorageResponseType {}
 
 @AdminOverrideAllowed
 /* according to docs, this is the appropriate permission, as of Jan 7, 2013 */
-@RequiresPermission([PolicySpec.S3_PUTLIFECYCLECONFIGURATION])
+@RequiresPermission(standard = [PolicySpec.S3_PUTLIFECYCLECONFIGURATION], version = [])
 @ResourceType(PolicySpec.S3_RESOURCE_BUCKET)
 @RequiresACLPermission(object = [], bucket = [], ownerOnly = true, ownerOf = [ObjectStorageProperties.Resource.bucket])
 public class DeleteBucketLifecycleType extends ObjectStorageRequestType {}
@@ -781,7 +783,7 @@ public class DeleteBucketLifecycleResponseType extends ObjectStorageResponseType
 
 /* PUT /bucket/?tagging */
 @AdminOverrideAllowed
-@RequiresPermission([PolicySpec.S3_PUTBUCKETTAGGING])
+@RequiresPermission(standard = [PolicySpec.S3_PUTBUCKETTAGGING], version = [])
 @ResourceType(PolicySpec.S3_RESOURCE_BUCKET)
 @RequiresACLPermission(object = [], bucket = [], ownerOnly = true, ownerOf = [ObjectStorageProperties.Resource.bucket])
 public class SetBucketTaggingType extends ObjectStorageRequestType {
@@ -792,7 +794,7 @@ public class SetBucketTaggingResponseType extends ObjectStorageResponseType {}
 
 /* GET /bucket/?tagging */
 @AdminOverrideAllowed
-@RequiresPermission([PolicySpec.S3_GETBUCKETTAGGING])
+@RequiresPermission(standard = [PolicySpec.S3_GETBUCKETTAGGING], version = [])
 @ResourceType(PolicySpec.S3_RESOURCE_BUCKET)
 @RequiresACLPermission(object = [], bucket = [], ownerOnly = true, ownerOf = [ObjectStorageProperties.Resource.bucket])
 public class GetBucketTaggingType extends ObjectStorageRequestType {}
@@ -803,7 +805,7 @@ public class GetBucketTaggingResponseType extends ObjectStorageResponseType {
 
 /* DELETE /bucket/?tagging */
 @AdminOverrideAllowed
-@RequiresPermission([PolicySpec.S3_PUTBUCKETTAGGING])
+@RequiresPermission(standard = [PolicySpec.S3_PUTBUCKETTAGGING], version = [])
 @ResourceType(PolicySpec.S3_RESOURCE_BUCKET)
 @RequiresACLPermission(object = [], bucket = [], ownerOnly = true, ownerOf = [ObjectStorageProperties.Resource.bucket])
 public class DeleteBucketTaggingType extends ObjectStorageRequestType {}
@@ -814,7 +816,7 @@ public class DeleteBucketTaggingResponseType extends ObjectStorageResponseType {
 
 /* PUT /bucket/?cors */
 @AdminOverrideAllowed
-@RequiresPermission([PolicySpec.S3_PUTBUCKETCORS])
+@RequiresPermission(standard = [PolicySpec.S3_PUTBUCKETCORS], version = [])
 @ResourceType(PolicySpec.S3_RESOURCE_BUCKET)
 @RequiresACLPermission(object = [], bucket = [], ownerOnly = true, ownerOf = [ObjectStorageProperties.Resource.bucket])
 public class SetBucketCorsType extends ObjectStorageRequestType {
@@ -825,7 +827,7 @@ public class SetBucketCorsResponseType extends ObjectStorageResponseType {}
 
 /* GET /bucket/?cors */
 @AdminOverrideAllowed
-@RequiresPermission([PolicySpec.S3_GETBUCKETCORS])
+@RequiresPermission(standard = [PolicySpec.S3_GETBUCKETCORS], version = [])
 @ResourceType(PolicySpec.S3_RESOURCE_BUCKET)
 @RequiresACLPermission(object = [], bucket = [], ownerOnly = true, ownerOf = [ObjectStorageProperties.Resource.bucket])
 public class GetBucketCorsType extends ObjectStorageRequestType {}
@@ -836,7 +838,7 @@ public class GetBucketCorsResponseType extends ObjectStorageResponseType {
 
 /* DELETE /bucket/?cors */
 @AdminOverrideAllowed
-@RequiresPermission([PolicySpec.S3_PUTBUCKETCORS])
+@RequiresPermission(standard = [PolicySpec.S3_PUTBUCKETCORS], version = [])
 @ResourceType(PolicySpec.S3_RESOURCE_BUCKET)
 @RequiresACLPermission(object = [], bucket = [], ownerOnly = true, ownerOf = [ObjectStorageProperties.Resource.bucket])
 public class DeleteBucketCorsType extends ObjectStorageRequestType {}
@@ -891,7 +893,7 @@ public class ObjectStorageComponentMessageResponseType extends ComponentMessageR
 
 
 @AdminOverrideAllowed
-@RequiresPermission([PolicySpec.S3_PUTOBJECT])
+@RequiresPermission(standard = [PolicySpec.S3_PUTOBJECT], version = [])
 @ResourceType(PolicySpec.S3_RESOURCE_OBJECT)
 @RequiresACLPermission(object = [], bucket = [ObjectStorageProperties.Permission.WRITE])
 //Account must have write access to the bucket
@@ -912,7 +914,7 @@ public class InitiateMultipartUploadResponseType extends ObjectStorageDataRespon
 }
 
 @AdminOverrideAllowed
-@RequiresPermission([PolicySpec.S3_PUTOBJECT])
+@RequiresPermission(standard = [PolicySpec.S3_PUTOBJECT], version = [])
 @ResourceType(PolicySpec.S3_RESOURCE_OBJECT)
 @RequiresACLPermission(object = [], bucket = [ObjectStorageProperties.Permission.WRITE], ownerOnly = true, ownerOf = [ObjectStorageProperties.Resource.object])
 //Account must have write access to the bucket and must be the initiator of mpu
@@ -930,7 +932,7 @@ public class UploadPartResponseType extends ObjectStorageDataResponseType {
 }
 
 @AdminOverrideAllowed
-@RequiresPermission([PolicySpec.S3_PUTOBJECT])
+@RequiresPermission(standard = [PolicySpec.S3_PUTOBJECT], version = [])
 @ResourceType(PolicySpec.S3_RESOURCE_OBJECT)
 @RequiresACLPermission(object = [], bucket = [ObjectStorageProperties.Permission.WRITE], ownerOnly = true, ownerOf = [ObjectStorageProperties.Resource.object])
 //Account must have write access to the bucket and must be the initiator of mpu
@@ -947,7 +949,7 @@ public class CompleteMultipartUploadResponseType extends ObjectStorageDataRespon
 }
 
 @AdminOverrideAllowed
-@RequiresPermission([PolicySpec.S3_ABORTMULTIPARTUPLOAD])
+@RequiresPermission(standard = [PolicySpec.S3_ABORTMULTIPARTUPLOAD], version = [])
 @ResourceType(PolicySpec.S3_RESOURCE_OBJECT)
 @RequiresACLPermission(object = [], bucket = [ObjectStorageProperties.Permission.WRITE], ownerOnly = true, ownerOf = [ObjectStorageProperties.Resource.bucket, ObjectStorageProperties.Resource.object])
 //Account must have write access to the bucket and must be either the bucket owning account or the initiator of mpu
@@ -959,7 +961,7 @@ public class AbortMultipartUploadResponseType extends ObjectStorageDataResponseT
 }
 
 @AdminOverrideAllowed
-@RequiresPermission([PolicySpec.S3_LISTMULTIPARTUPLOADPARTS])
+@RequiresPermission(standard = [PolicySpec.S3_LISTMULTIPARTUPLOADPARTS], version = [])
 @ResourceType(PolicySpec.S3_RESOURCE_OBJECT)
 @RequiresACLPermission(object = [], bucket = [ObjectStorageProperties.Permission.READ], ownerOnly = true, ownerOf = [ObjectStorageProperties.Resource.bucket, ObjectStorageProperties.Resource.object])
 //Account must have read access to the bucket and must be either the bucket owning account or the initiator of mpu
@@ -984,7 +986,7 @@ public class ListPartsResponseType extends ObjectStorageDataResponseType {
 }
 
 @AdminOverrideAllowed
-@RequiresPermission([PolicySpec.S3_LISTBUCKETMULTIPARTUPLOADS])
+@RequiresPermission(standard = [PolicySpec.S3_LISTBUCKETMULTIPARTUPLOADS], version = [])
 @ResourceType(PolicySpec.S3_RESOURCE_BUCKET)
 @RequiresACLPermission(object = [], bucket = [ObjectStorageProperties.Permission.READ])
 //Account must have read access to the bucket

--- a/clc/modules/object-storage-common/src/main/java/com/eucalyptus/objectstorage/msgs/ObjectStorage.groovy
+++ b/clc/modules/object-storage-common/src/main/java/com/eucalyptus/objectstorage/msgs/ObjectStorage.groovy
@@ -38,9 +38,9 @@ import com.eucalyptus.objectstorage.util.ObjectStorageProperties
 import com.eucalyptus.storage.msgs.BucketLogData
 import com.eucalyptus.storage.msgs.s3.AccessControlList
 import com.eucalyptus.storage.msgs.s3.AccessControlPolicy
-import com.eucalyptus.storage.msgs.s3.CorsConfiguration;
 import com.eucalyptus.storage.msgs.s3.CanonicalUser
 import com.eucalyptus.storage.msgs.s3.CommonPrefixesEntry
+import com.eucalyptus.storage.msgs.s3.CorsConfiguration
 import com.eucalyptus.storage.msgs.s3.DeleteMultipleObjectsMessage
 import com.eucalyptus.storage.msgs.s3.DeleteMultipleObjectsMessageReply
 import com.eucalyptus.storage.msgs.s3.Initiator
@@ -518,7 +518,7 @@ public class CopyObjectType extends ObjectStorageRequestType {
 /* HEAD /bucket/object */
 
 @AdminOverrideAllowed
-@RequiresPermission([PolicySpec.S3_HEADOBJECT])
+@RequiresPermission([PolicySpec.S3_GETOBJECT])
 @ResourceType(PolicySpec.S3_RESOURCE_OBJECT)
 @RequiresACLPermission(object = [ObjectStorageProperties.Permission.READ], bucket = [])
 public class HeadObjectType extends ObjectStorageDataGetRequestType {

--- a/clc/modules/object-storage-common/src/main/java/com/eucalyptus/objectstorage/policy/RequiresPermission.java
+++ b/clc/modules/object-storage-common/src/main/java/com/eucalyptus/objectstorage/policy/RequiresPermission.java
@@ -36,6 +36,10 @@ public @interface RequiresPermission {
   /**
    * The set of IAM policies, from {@link PolicySpec} that
    */
-  String[] value();
+  String[] standard();
 
+  /**
+   * The set of IAM policies that apply to the request with a version ID
+   */
+  String[] version();
 }

--- a/clc/modules/object-storage-common/src/main/resources/osg-binding.xml
+++ b/clc/modules/object-storage-common/src/main/resources/osg-binding.xml
@@ -55,6 +55,7 @@
         <value name="Timestamp" field="timeStamp" usage="optional"/>
         <value name="Bucket" field="bucket" usage="optional"/>
         <value name="Key" field="key" usage="optional"/>
+        <value name="VersionId" field="versionId" usage="optional"/>
     </mapping>
 
     <mapping
@@ -209,7 +210,6 @@
         <structure
                 map-as="com.eucalyptus.objectstorage.msgs.ObjectStorageRequestType"
                 usage="optional"/>
-        <value name="VersionId" field="versionId" usage="optional"/>
     </mapping>
 
     <mapping
@@ -227,7 +227,6 @@
         <structure
                 map-as="com.eucalyptus.objectstorage.msgs.ObjectStorageRequestType"
                 usage="optional"/>
-        <value name="VersionId" field="versionId" usage="optional"/>
     </mapping>
 
     <mapping name="SetObjectAccessControlPolicyTypeResponse"
@@ -405,7 +404,6 @@
                 usage="optional"/>
         <value name="DeleteAfterGet" field="deleteAfterGet" usage="optional"/>
         <value name="GetTorrent" field="getTorrent" usage="optional"/>
-        <value name="VersionId" field="versionId" usage="optional"/>
     </mapping>
 
     <mapping name="GetObjectResponse"
@@ -430,7 +428,6 @@
         <value name="IfMatch" field="ifMatch"/>
         <value name="IfNoneMatch" field="ifNoneMatch"/>
         <value name="ReturnCompleteObjectOnConditionFailure" field="returnCompleteObjectOnConditionFailure"/>
-        <value name="VersionId" field="versionId" usage="optional"/>
         <structure
                 map-as="com.eucalyptus.objectstorage.msgs.ObjectStorageRequestType"
                 usage="optional"/>
@@ -451,7 +448,6 @@
         <structure
                 map-as="com.eucalyptus.objectstorage.msgs.ObjectStorageRequestType"
                 usage="optional"/>
-        <value name="VersionId" field="versionId" usage="optional"/>
     </mapping>
 
     <mapping name="HeadObjectResponse"
@@ -488,7 +484,6 @@
         <structure
                 map-as="com.eucalyptus.objectstorage.msgs.ObjectStorageRequestType"
                 usage="optional"/>
-        <value name="versionId" field="versionId"/>
     </mapping>
 
     <mapping name="DeleteVersionResponse"

--- a/clc/modules/object-storage/src/main/java/com/eucalyptus/objectstorage/auth/OsgAuthorizationHandler.java
+++ b/clc/modules/object-storage/src/main/java/com/eucalyptus/objectstorage/auth/OsgAuthorizationHandler.java
@@ -25,6 +25,7 @@ import java.util.Collections;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.Logger;
 
 import com.eucalyptus.auth.Accounts;
@@ -109,7 +110,13 @@ public class OsgAuthorizationHandler implements RequestAuthorizationHandler {
     String[] requiredActions = null;
     RequiresPermission perms = requestAuthzProperties.get(RequiresPermission.class);
     if (perms != null) {
-      requiredActions = perms.value();
+      // check for version specific IAM permissions and version Id in the request
+      if (perms.version() != null && perms.version().length > 0 && StringUtils.isNotBlank(request.getVersionId())
+          && !StringUtils.equalsIgnoreCase(request.getVersionId(), ObjectStorageProperties.NULL_VERSION_ID)) {
+        requiredActions = perms.version(); // Use version specific IAM perms
+      } else {
+        requiredActions = perms.standard(); // Use default/standard IAM perms
+      }
     }
 
     Boolean allowAdmin = (requestAuthzProperties.get(AdminOverrideAllowed.class) != null);


### PR DESCRIPTION
- EUCA-11809: Use annotations on OSG messages for versioned and non-versioned IAM permissions. Choose the permissions to be evaluated based on the inbound request and annotations on the messages
- EUCA-11823: Change the IAM permission for S3 head operation from s3:HeadObject to s3:GetObject
